### PR TITLE
fix clearing of bit 8 in SHDN

### DIFF
--- a/src/mcp9808.cpp
+++ b/src/mcp9808.cpp
@@ -138,7 +138,7 @@ int8_t MCPClass::wake(void) {
 
     /* Check if shutdown bit is set */
     if (reg & (1 << 8)) {
-        regWrite16(POINTER_CONFIG, reg | (0 << 8)); // Clear bit 8 (SHDN)
+        regWrite16(POINTER_CONFIG, reg & ~(0 << 8)); // Clear bit 8 (SHDN)
     } else {
 #ifdef DEBUG
         SerialDebug.println("Error: shutdown (SHDN) bit not set");


### PR DESCRIPTION
Copy and paste error of clearing the bit was fixed. 
`Wakeup` function now works as expected.